### PR TITLE
Sorts damage types in alphabethical order.

### DIFF
--- a/src/module/persistent-effect.ts
+++ b/src/module/persistent-effect.ts
@@ -2,24 +2,24 @@ import { ItemPF2e } from "@pf2e/module/item";
 import { EffectData, ItemDataPF2e } from "@pf2e/module/item/data";
 
 export const typeImages: Record<string, ImagePath> = {
-    bleed: "systems/pf2e/icons/spells/blade-barrier.webp",
-    piercing: "systems/pf2e/icons/equipment/weapons/throwing-knife.webp",
-    bludgeoning: "systems/pf2e/icons/equipment/weapons/bola.webp",
-    slashing: "systems/pf2e/icons/equipment/weapons/scimitar.webp",
-    fire: "systems/pf2e/icons/spells/flaming-sphere.webp",
     acid: "systems/pf2e/icons/spells/blister.webp",
+    bleed: "systems/pf2e/icons/spells/blade-barrier.webp",
+    bludgeoning: "systems/pf2e/icons/equipment/weapons/bola.webp",
+    chaotic: "systems/pf2e/icons/spells/dinosaur-form.webp",
     cold: "systems/pf2e/icons/spells/chilling-spray.webp",
     electricity: "systems/pf2e/icons/spells/chain-lightning.webp",
-    sonic: "systems/pf2e/icons/spells/cry-of-destruction.webp",
-    force: "systems/pf2e/icons/spells/magic-missile.webp",
-    mental: "systems/pf2e/icons/spells/modify-memory.webp",
-    poison: "systems/pf2e/icons/spells/acidic-burst.webp",
-    lawful: "systems/pf2e/icons/equipment/adventuring-gear/merchant-scale.webp",
-    chaotic: "systems/pf2e/icons/spells/dinosaur-form.webp",
-    good: "systems/pf2e/icons/spells/angelic-wings.webp",
     evil: "systems/pf2e/icons/spells/daemonic-pact.webp",
-    positive: "systems/pf2e/icons/spells/moment-of-renewal.webp",
+    fire: "systems/pf2e/icons/spells/flaming-sphere.webp",
+    force: "systems/pf2e/icons/spells/magic-missile.webp",
+    good: "systems/pf2e/icons/spells/angelic-wings.webp",
+    lawful: "systems/pf2e/icons/equipment/adventuring-gear/merchant-scale.webp",
+    mental: "systems/pf2e/icons/spells/modify-memory.webp",
     negative: "systems/pf2e/icons/spells/grim-tendrils.webp",
+    piercing: "systems/pf2e/icons/equipment/weapons/throwing-knife.webp",
+    poison: "systems/pf2e/icons/spells/acidic-burst.webp",
+    positive: "systems/pf2e/icons/spells/moment-of-renewal.webp",
+    slashing: "systems/pf2e/icons/equipment/weapons/scimitar.webp",
+    sonic: "systems/pf2e/icons/spells/cry-of-destruction.webp",
 };
 
 export type DamageType = keyof typeof typeImages;


### PR DESCRIPTION
I've run with this locally for a while - before I sorted the list I could never manage to find good when the paladin in the group did persistent good... - and rather like it, so I figured I'd make a PR in case you also like it, though I suppose the current ordering by type probably works fine for everyone but me. :)
(In fact, only now that I've pushed the PR I've realized that there *is* an order to the original.  It's'physical','elemental','alignment','lifetype'. I just didn't see it before today, it's always just seemed like a random order to my mind...)

![image](https://user-images.githubusercontent.com/246024/196042631-f6306feb-4a6d-4dcf-840c-aea9593bd3a7.png)
